### PR TITLE
Fix: Add missing libboost-graph-dev

### DIFF
--- a/install
+++ b/install
@@ -26,6 +26,7 @@ apt-get install -y  \
   libboost-serialization-dev \
   libboost-system-dev \
   libboost-test-dev \
+  libboost-graph-dev \
   libcgal-dev \
   libcgal-qt5-dev \
   libeigen3-dev \


### PR DESCRIPTION
`docker build -t dpg .` produces this error:

```
CMake Error at /usr/share/cmake-3.7/Modules/FindBoost.cmake:1831 (message):
  Unable to find the requested Boost libraries.

  Boost version: 1.62.0

  Boost include path: /usr/include

  Could not find the following static Boost libraries:

          boost_graph

  Some (but not all) of the required Boost libraries were found.  You may
  need to install these additional Boost libraries.  Alternatively, set
  BOOST_LIBRARYDIR to the directory containing Boost libraries or BOOST_ROOT
  to the location of Boost.
Call Stack (most recent call first):
  CMakeLists.txt:89 (find_package)
```

I added a line to install `libboost-graph-dev` in the image to fix this error.