### PR TITLE
Fix parser arg

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -94,7 +94,7 @@ def createParser():
         choices=[1, 2, 3])
 
     openmvs = parser.add_argument_group('OpenMVS')
-    openmvs.add_argument('--out-putobj',
+    openmvs.add_argument('--output-obj',
         action='store_true',
         help='Output mesh files as obj instead of ply')
 


### PR DESCRIPTION
This PR fixes [the definition of the parser option `out-putobj`](https://github.com/rennu/dpg/blob/master/pipeline.py#L97) referred as [`output_obj`](https://github.com/rennu/dpg/blob/master/pipeline.py#L216).

I would be pleased if this PR could help.

