### PR TITLE
Fix densify when using --output-obj

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -233,7 +233,6 @@ def createCommands(args):
         densifyPointCloudOptions += ['--number-views', args.dnviews]
     if args.dreslevel != None:
         densifyPointCloudOptions += ['--resolution-level', args.dreslevel]
-    densifyPointCloudOptions += openmvsOutputFormat
 
     # OpenMVS Reconstruct Mesh
     if args.rcthickness != None:


### PR DESCRIPTION
Densify doesn't seem to accept the `--export-type obj` flag